### PR TITLE
Allow option to override the label for the menu option in assets section

### DIFF
--- a/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
+++ b/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
@@ -121,7 +121,15 @@ class CloudfrontInvalidationPlugin extends BasePlugin
     protected function defineSettings()
     {
         return array(
-            'distributionId' => array(AttributeType::String, 'label' => 'CloudFront Distribution ID', 'default' => ''),
+                'distributionId' => array(AttributeType::String, 
+                'label' => 'CloudFront Distribution ID', 
+                'default' => ''
+            ),
+
+                'assetMenuLabelOverride' => array(AttributeType::String, 
+                'label' => 'Override asset menu option label', 
+                'default' => ''
+            ),
         );
     }
 

--- a/cloudfrontinvalidation/elementactions/CloudfrontInvalidation_InvalidateElementAction.php
+++ b/cloudfrontinvalidation/elementactions/CloudfrontInvalidation_InvalidateElementAction.php
@@ -5,7 +5,11 @@ class CloudfrontInvalidation_InvalidateElementAction extends BaseElementAction
 {
     public function getName()
     {
-        return Craft::t('Invalidate CloudFront cache');
+        $pluginSettings = craft()->plugins->getPlugin('cloudfrontinvalidation')->getSettings();
+        $assetMenuLabel = Craft::t('Invalidate CloudFront cache');
+        $assetMenuLabelOverride = $pluginSettings->assetMenuLabelOverride;
+
+        return ($assetMenuLabelOverride) ? $assetMenuLabelOverride : $assetMenuLabel;
     }
 
     public function performAction(ElementCriteriaModel $criteria)

--- a/cloudfrontinvalidation/templates/CloudfrontInvalidation_Settings.twig
+++ b/cloudfrontinvalidation/templates/CloudfrontInvalidation_Settings.twig
@@ -22,3 +22,11 @@
     placeholder: 'xxxxxxxxxxxxx',
     value: settings['distributionId']})
 }}
+
+{{ forms.textField({
+    label: 'Override asset menu option label',
+    instructions: 'This will override the default label used in the assets section. This can be useful for making the option more meaningful for editors.',
+    id: 'assetMenuLabelOverride',
+    name: 'assetMenuLabelOverride',
+    value: settings['assetMenuLabelOverride']})
+}}


### PR DESCRIPTION
@sjelfull 

Hi, from a editor point of view it would be nice to be able to control the label of menu option for invalidating the CloudFront cache, mainly because less tech savvy editors will probably not know what CloudFront is, so being able to label it as a more generic option such as "Clear asset cache" would be useful.

This PR adds the additional string field to override the default label.