### PR TITLE
Make CloudFront Distribution ID a required field

### DIFF
--- a/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
+++ b/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
@@ -121,7 +121,11 @@ class CloudfrontInvalidationPlugin extends BasePlugin
     protected function defineSettings()
     {
         return array(
-            'distributionId' => array(AttributeType::String, 'label' => 'CloudFront Distribution ID', 'default' => ''),
+                'distributionId' => array(AttributeType::String, 
+                'label' => 'CloudFront Distribution ID', 
+                'default' => '',
+                'required' => true,
+            ),
         );
     }
 

--- a/cloudfrontinvalidation/templates/CloudfrontInvalidation_Settings.twig
+++ b/cloudfrontinvalidation/templates/CloudfrontInvalidation_Settings.twig
@@ -17,8 +17,10 @@
 {{ forms.textField({
     label: 'CloudFront Distribution ID',
     instructions: 'You can find the distribution ID in <a href="https://console.aws.amazon.com/cloudfront/home" target="_blank">the AWS console</a>',
+    required: true,
     id: 'distributionId',
     name: 'distributionId',
     placeholder: 'xxxxxxxxxxxxx',
-    value: settings['distributionId']})
+    value: settings['distributionId'],
+    errors: settings.getErrors('distributionId')})
 }}


### PR DESCRIPTION
@sjelfull Given the plugin is based around a valid AWS CloudFront distribution ID, I thought it was probably useful to make it a required field.