### PR TITLE
Fix merge issue with required being set on the wrong setting

### DIFF
--- a/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
+++ b/cloudfrontinvalidation/CloudfrontInvalidationPlugin.php
@@ -124,13 +124,13 @@ class CloudfrontInvalidationPlugin extends BasePlugin
                 'distributionId' => array(
                      AttributeType::String, 
                     'label' => 'CloudFront Distribution ID', 
-                    'default' => ''
+                    'default' => '',
+                    'required' => true
                 ),
                 'assetMenuLabelOverride' => array(
                     AttributeType::String, 
                   'label' => 'Override asset menu option label', 
                   'default' => ''
-                  'required' => true,
             ),
         );
     }


### PR DESCRIPTION
@sjelfull Looks like the the required parameter in the array ended up on the wrong field, I think its due to the merge conflict, given the PRs tripped over each other! Apologies, this should fix it.